### PR TITLE
Kb new gnss metadata fields

### DIFF
--- a/CollectorUtils/pro/add_update_gnss_fields_python_api.md
+++ b/CollectorUtils/pro/add_update_gnss_fields_python_api.md
@@ -7,9 +7,17 @@ This script/tool attempts to add the following fields to a Point Feature Class:
 
 | Attribute            | Field Alias             | Field Name           | Field Type  | Domain               | Notes                                                                                    |
 |----------------------|-------------------------|----------------------|-------------|----------------------|------------------------------------------------------------------------------------------|
+| Direction of travel        | Direction of travel (°)           | ESRIGNSS_DIRECTION    | double |                      |
+
+| Speed        | Speed (km/h)           | ESRIGNSS_SPEED    | double |                      |
+
+| Compass reading        | Compass reading (°)           | ESRISNSR_AZIMUTH    | double |                      |
+
+| Position source type        | Position source type           | ESRIGNSS_POSITIONSOURCETYPE    | Short |        0 - Unknown <br/>1 - User defined <br/>2 - Integrated (System) Location Provider <br/>3 - External GNSS Receiver <br/>4 - Network Location Provider              |
+
 | Receiver name        | Receiver Name           | ESRIGNSS_RECEIVER    | String(50) |                      |                                                                                          |
-| Horizontal nccuracy  | Horizontal Accuracy (m) | ESRIGNSS_H_RMS       | double      |                      |                                                                                          |
-| Vertical nccuracy    | Vertical Accuracy (m)   | ESRIGNSS_V_RMS       | double      |                      |                                                                                          |
+| Horizontal accuracy  | Horizontal Accuracy (m) | ESRIGNSS_H_RMS       | double      |                      |                                                                                          |
+| Vertical accuracy    | Vertical Accuracy (m)   | ESRIGNSS_V_RMS       | double      |                      |                                                                                          |
 | Latitude             | Latitude                | ESRIGNSS_LATITUDE    | double      |                      |                                                                                          |
 | Longitude            | Longitude               | ESRIGNSS_LONGITUDE   | double      |                      |                                                                                          |
 | Altitude             | Altitude                | ESRIGNSS_ALTITUDE    | double      |                      |                                                                                          |

--- a/CollectorUtils/pro/add_update_gnss_fields_python_api.md
+++ b/CollectorUtils/pro/add_update_gnss_fields_python_api.md
@@ -7,14 +7,10 @@ This script/tool attempts to add the following fields to a Point Feature Class:
 
 | Attribute            | Field Alias             | Field Name           | Field Type  | Domain               | Notes                                                                                    |
 |----------------------|-------------------------|----------------------|-------------|----------------------|------------------------------------------------------------------------------------------|
-| Direction of travel        | Direction of travel (°)           | ESRIGNSS_DIRECTION    | double |                      |
-
-| Speed        | Speed (km/h)           | ESRIGNSS_SPEED    | double |                      |
-
-| Compass reading        | Compass reading (°)           | ESRISNSR_AZIMUTH    | double |                      |
-
-| Position source type        | Position source type           | ESRIGNSS_POSITIONSOURCETYPE    | Short |        0 - Unknown <br/>1 - User defined <br/>2 - Integrated (System) Location Provider <br/>3 - External GNSS Receiver <br/>4 - Network Location Provider              |
-
+| Direction of travel        | Direction of travel (°)           | ESRIGNSS_DIRECTION    | double |                      |                                                                                          |
+| Speed        | Speed (km/h)           | ESRIGNSS_SPEED    | double |                      |                      |                                                                                          |
+| Compass reading        | Compass reading (°)           | ESRISNSR_AZIMUTH    | double |                      |                                                                                          |
+| Position source type        | Position source type           | ESRIGNSS_POSITIONSOURCETYPE    | Short |        0 - Unknown <br/>1 - User defined <br/>2 - Integrated (System) Location Provider <br/>3 - External GNSS Receiver <br/>4 - Network Location Provider               |                                                                                          |
 | Receiver name        | Receiver Name           | ESRIGNSS_RECEIVER    | String(50) |                      |                                                                                          |
 | Horizontal accuracy  | Horizontal Accuracy (m) | ESRIGNSS_H_RMS       | double      |                      |                                                                                          |
 | Vertical accuracy    | Vertical Accuracy (m)   | ESRIGNSS_V_RMS       | double      |                      |                                                                                          |

--- a/CollectorUtils/pro/configure_gnss_popup_python_api.md
+++ b/CollectorUtils/pro/configure_gnss_popup_python_api.md
@@ -1,5 +1,5 @@
 # Configure GNSS Metadata fields visibility and Popup
-Supported in ArcGIS Pro 2.0+ - requires Python API version 1.4.2  - https://developers.arcgis.com/python/guide/install-and-set-up/
+Supported in ArcGIS Pro 2.0+ - requires Python API version 1.4.2+  - https://developers.arcgis.com/python/guide/install-and-set-up/
 
 | Field name | Alias | Format |
 |---|---|---|

--- a/CollectorUtils/pro/configure_gnss_popup_python_api.md
+++ b/CollectorUtils/pro/configure_gnss_popup_python_api.md
@@ -1,7 +1,32 @@
 # Configure GNSS Metadata fields visibility and Popup
 Supported in ArcGIS Pro 2.0+ - requires Python API version 1.4.2  - https://developers.arcgis.com/python/guide/install-and-set-up/
 
-![capture](https://user-images.githubusercontent.com/26557666/28002733-a8560878-64ec-11e7-826b-fdace77cef6a.PNG)
+| Field name | Alias | Format |
+|---|---|---|
+| ESRIGNSS_DIRECTION | Direction of travel (°) | 2 decimal places |
+| ESRIGNSS_SPEED | Speed (km/h) | 2 decimal places |
+| ESRISNSR_AZIMUTH | Compass reading (°) | 2 decimal places |
+| ESRIGNSS_POSITIONSOURCETYPE | Position source type | NA |
+| ESRIGNSS_RECEIVER | Receiver Name | NA |
+| ESRIGNSS_H_RMS | Horizontal Accuracy (m) | 2 decimal places |
+| ESRIGNSS_V_RMS | Vertical Accuracy (m) | 2 decimal places |
+| ESRIGNSS_LATITUDE | Latitude | 8 decimal places |
+| ESRIGNSS_LONGITUDE | Longitude | 8 decimal places |
+| ESRIGNSS_ALTITUDE | Altitude | 2 decimal places |
+| ESRIGNSS_PDOP | PDOP | 2 decimal places |
+| ESRIGNSS_HDOP | HDOP | 2 decimal places |
+| ESRIGNSS_VDOP | VDOP | 2 decimal places |
+| ESRIGNSS_FIXTYPE | Fix Type | NA |
+| ESRIGNSS_CORRECTIONAGE | Correction Age (seconds) | 0 decimal places |
+| ESRIGNSS_STATIONID | Station ID | NA |
+| ESRIGNSS_NUMSATS | Number of Satellites | NA |
+| ESRIGNSS_FIXDATETIME | Fix Time | ShortDateTime, 12hr |
+| ESRIGNSS_AVG_H_RMS | Average Horizontal Accuracy (m) | 2 decimal places |
+| ESRIGNSS_AVG_V_RMS | Average Vertical Accuracy (m) | 2 decimal places |
+| ESRIGNSS_AVG_POSITIONS | Averaged Positions | NA |
+| ESRIGNSS_H_STDDEV| Standard Deviation (m) | 3 decimal places |
+
+**Note** Prior to running the tool, for hosted feature services published using ArcGIS Pro, once added into a new web map in ArcGIS Online/ArcGIS Enterprise, click `Save Layer`.
 
 # Intructions to run from Pro.
 ![image](https://user-images.githubusercontent.com/26557666/28002780-05812fbe-64ed-11e7-975e-1b7e63bc2c83.png)

--- a/CollectorUtils/scripts/add_update_gnss_fields_python_api.py
+++ b/CollectorUtils/scripts/add_update_gnss_fields_python_api.py
@@ -79,6 +79,82 @@ def searchItems_addGNSSMetadataFields(args_parser):
         # Add/Update GNSS Metadata fields
         if not args_parser.remove:
 
+            # ESRIGNSS_DIRECTION
+            directionField = [field for field in featureLayerFields if field['name'] == 'ESRIGNSS_DIRECTION']
+
+            if not directionField:
+                gnssMetadataFields['fields'].append({'name': 'ESRIGNSS_DIRECTION',
+                                                     'type': 'esriFieldTypeDouble',
+                                                     'alias': 'Direction of travel (°)',
+                                                     'sqlType': 'sqlTypeOther',
+                                                     'nullable': True,
+                                                     'editable': True,
+                                                     'domain': None,
+                                                     'defaultValue': None})
+
+            # ESRIGNSS_SPEED
+            speedField = [field for field in featureLayerFields if field['name'] == 'ESRIGNSS_SPEED']
+
+            if not speedField:
+                gnssMetadataFields['fields'].append({'name': 'ESRIGNSS_SPEED',
+                                                     'type': 'esriFieldTypeDouble',
+                                                     'alias': 'Speed (km/h)',
+                                                     'sqlType': 'sqlTypeOther',
+                                                     'nullable': True,
+                                                     'editable': True,
+                                                     'domain': None,
+                                                     'defaultValue': None})
+
+            # ESRISNSR_AZIMUTH
+            azimuthField = [field for field in featureLayerFields if field['name'] == 'ESRISNSR_AZIMUTH']
+
+            if not azimuthField:
+                gnssMetadataFields['fields'].append({'name': 'ESRISNSR_AZIMUTH',
+                                                     'type': 'esriFieldTypeDouble',
+                                                     'alias': 'Compass reading (°)',
+                                                     'sqlType': 'sqlTypeOther',
+                                                     'nullable': True,
+                                                     'editable': True,
+                                                     'domain': None,
+                                                     'defaultValue': None})
+
+            # ESRIGNSS_POSITIONSOURCETYPE
+            positionsourcetypeField = [field for field in featureLayerFields if field['name'] == 'ESRIGNSS_POSITIONSOURCETYPE']
+
+            if positionsourcetypeField:
+                # Field does exist check if the domain is set.
+                if positionsourcetypeField[0]['domain'] == None:
+                    if ([operation for operation in operations if operation == 'updateDefinition']):
+                        operations.append('updateDefinition')
+
+                    positionsourcetypeFieldIndex = featureLayerFields.index(positionsourcetypeField[0])
+                    positionsourcetypeDomain = {'type': 'codedValue',
+                                     'name': 'ESRI_POSITIONSOURCETYPE_DOMAIN',
+                                     'codedValues': [{'name': 'Unknown',
+                                                      'code': 0},
+                                                     {'name': 'User defined', 'code': 1},
+                                                     {'name': 'Integrated (System) Location Provider', 'code': 2},
+                                                     {'name': 'External GNSS Receiver', 'code': 3},
+                                                     {'name': 'Network Location Provider', 'code': 4}]}
+                    featureLayerFields[positionsourcetypeFieldIndex]['domain'] = positionsourcetypeDomain
+
+            else:
+                gnssMetadataFields['fields'].append({'name': 'ESRIGNSS_POSITIONSOURCETYPE',
+                                                     'type': 'esriFieldTypeInteger',
+                                                     'alias': 'Position source type',
+                                                     'sqlType': 'sqlTypeOther',
+                                                     'nullable': True,
+                                                     'editable': True,
+                                                     'domain': {'type': 'codedValue',
+                                                                'name': 'ESRI_POSITIONSOURCETYPE_DOMAIN',
+                                                                'codedValues': [
+                                                                    {'name': 'Unknown', 'code': 0},
+                                                                    {'name': 'User defined', 'code': 1},
+                                                                    {'name': 'Integrated (System) Location Provider', 'code': 2},
+                                                                    {'name': 'External GNSS Receiver', 'code': 3},
+                                                                    {'name': 'Network Location Provider', 'code': 4}]},
+                                                     'defaultValue': None})
+
             # ESRIGNSS_RECEIVER
             recieverField = [field for field in featureLayerFields if field['name'] == 'ESRIGNSS_RECEIVER']
             
@@ -377,7 +453,11 @@ def searchItems_addGNSSMetadataFields(args_parser):
         else:
             operations.append('deleteFromDefinition')
             gnssMetadataFields = {
-                'fields': [{'name': 'ESRIGNSS_FIXDATETIME'},
+                'fields': [{'name': 'ESRIGNSS_DIRECTION'},
+                           {'name': 'ESRIGNSS_SPEED'},
+                           {'name': 'ESRISNSR_AZIMUTH'},
+                           {'name': 'ESRIGNSS_POSITIONSOURCETYPE'},
+                           {'name': 'ESRIGNSS_FIXDATETIME'},
                            {'name': 'ESRIGNSS_RECEIVER'},
                            {'name': 'ESRIGNSS_H_RMS'},
                            {'name': 'ESRIGNSS_V_RMS'},

--- a/CollectorUtils/scripts/configure_gnss_popup_python_api.py
+++ b/CollectorUtils/scripts/configure_gnss_popup_python_api.py
@@ -94,6 +94,30 @@ def searchItems_UpdateGNSSMetadataFieldsPopup(args_parser):
         
         for field_info in fieldInfos:
             # Configure popup and visibility for GNSSMetadata fields
+            if field_info['fieldName'].upper() == 'ESRIGNSS_DIRECTION':
+                if 'format' in field_info.keys():
+                    field_info['format']['places'] = 2
+                else:
+                    field_info['format'] = {'places' : 2}
+                field_info['visible'] = True
+                field_info['isEditable'] = False
+
+            if field_info['fieldName'].upper() == 'ESRIGNSS_SPEED':
+                if 'format' in field_info.keys():
+                    field_info['format']['places'] = 2
+                else:
+                    field_info['format'] = {'places' : 2}
+                field_info['visible'] = True
+                field_info['isEditable'] = False
+
+            if field_info['fieldName'].upper() == 'ESRISNSR_AZIMUTH':
+                if 'format' in field_info.keys():
+                    field_info['format']['places'] = 2
+                else:
+                    field_info['format'] = {'places' : 2}
+                field_info['visible'] = True
+                field_info['isEditable'] = False
+
             if field_info['fieldName'].upper() == 'ESRIGNSS_H_RMS':
                 if 'format' in field_info.keys():
                     field_info['format']['places'] = 2
@@ -202,7 +226,8 @@ def searchItems_UpdateGNSSMetadataFieldsPopup(args_parser):
             if field_info['fieldName'].upper() == 'ESRIGNSS_RECEIVER' or field_info[
                 'fieldName'].upper() == 'ESRIGNSS_STATIONID' or \
                             field_info['fieldName'].upper() == 'ESRIGNSS_FIXTYPE' or field_info[
-                'fieldName'].upper() == 'ESRIGNSS_NUMSATS' or \
+                'fieldName'].upper() == 'ESRIGNSS_NUMSATS' or field_info[
+                'fieldName'].upper() == 'ESRIGNSS_POSITIONSOURCETYPE' or \
                             field_info['fieldName'].upper() == 'ESRIGNSS_AVG_POSITIONS':
                 field_info['visible'] = True
                 field_info['isEditable'] = False


### PR DESCRIPTION
Added the four new metadata fields:
| Field | Type | Alias | Notes|
|---|---|---|---|
| esrignss_direction | double | Direction of travel (°) | |
| esrignss_speed | double | Speed (km/h) | |
| esrisnsr_azimuth | double | Compass reading (°) | Compass reading from device |
| esrignss_positionsourcetype | integer | Position source type | Domain (see below) |

**esrignss_positionsourcetype domain values**
Unknown (0)
User defined (1)
Integrated (System) Location Provider (2)
External GNSS Receiver (3)
Network Location Provider (4)

Updated:
add_update_gnss_fields.py
add_update_gnss_fields_python_api.py
configure_gnss_popup_python_api.py
